### PR TITLE
Move to Findbugs 3 to add support for Java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "findbugs4sbt"
 
 organization := "de.johoop"
 
-version := "1.3.0"
+version := "1.4.0"
 
 scalaVersion := "2.10.3"
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This SBT plug-in enables you to analyze your (Java) code with the help of the great **[FindBugs](http://findbugs.sourceforge.net/)** tool. It defines a `findbugs` sbt action for that purpose.
 
-Version 1.3.0 of this plug-in is available for SBT 0.13.x.
+Version 1.4.0 of this plug-in is available for SBT 0.13.x.
 
 ## Getting findbugs4sbt
 
@@ -27,7 +27,7 @@ findbugsSettings
 Also, you have to add the plugin dependency to your project's `./project/plugins.sbt` or the global  `.sbt/plugins/build.sbt`:
 
 ```scala
-addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.3.0")
+addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 ```
 
 The old settings specified below are still mostly valid, but they're now specified using the settings system of SBT 0.13.

--- a/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
@@ -88,8 +88,8 @@ private[findbugs4sbt] trait Settings extends Plugin {
   val findbugsSettings = Seq(
     ivyConfigurations += findbugsConfig,
     libraryDependencies ++= Seq(
-      "com.google.code.findbugs" % "findbugs" % "2.0.3" % "findbugs->default",
-      "com.google.code.findbugs" % "jsr305" % "2.0.3" % "findbugs->default"
+      "com.google.code.findbugs" % "findbugs" % "3.0.0" % "findbugs->default",
+      "com.google.code.findbugs" % "jsr305" % "3.0.0" % "findbugs->default"
     ),
       
     findbugs <<= (findbugsClasspath, managedClasspath in Compile, 


### PR DESCRIPTION
@jmhofer I added support for FB3 to address https://github.com/sbt/findbugs4sbt/issues/9

I tested it locally against a new Play-Java project