### PR TITLE
Add FindBugs failOnError setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ findbugsIncludeFilters := {
 * *Accepts:* `true` and `false`
 * *Default:* `false`
 
+### `findbugsFailOnError`
+* *Description:* Whether the build should be failed if there are any reported bug instances.
+* *Accepts:* `true` and `false`
+* *Default:* `false`
+
 ### `findbugsIncludeFilters`
 * *Description:* Optional filter file XML content defining which bug instances to include in the static analysis.
 * *Accepts:* `None` and `Option[Node]`

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "findbugs4sbt"
 
 organization := "de.johoop"
 
-version := "1.4.0"
+version := "1.4.1-SNAPSHOT"
 
 scalaVersion := "2.10.3"
 

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,0 +1,3 @@
+libraryDependencies <+= (sbtVersion) { sv =>
+  "org.scala-sbt" % "scripted-plugin" % sv
+}

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,0 +1,7 @@
+ScriptedPlugin.scriptedSettings
+
+scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+  Seq("-Xmx1024M", "-XX:MaxPermSize=256M", "-Dplugin.version=" + version.value)
+}
+
+scriptedBufferLog := false

--- a/src/main/scala/de/johoop/findbugs4sbt/CommandLine.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/CommandLine.scala
@@ -40,7 +40,7 @@ private[findbugs4sbt] trait CommandLine extends Plugin with Filters with Setting
     def findbugsCallArguments = paths.analyzedPath map (_.getPath)
     
     def findbugsCallOptions = {
-      if (paths.reportPath.isDefined && ! misc.reportType.isDefined) 
+      if (paths.reportPath.isDefined && misc.reportType.isEmpty)
         sys.error("If a report path is defined, a report type is required!")
 
       val auxClasspath = paths.auxPath ++ (findbugsClasspath.files filter (_.getName startsWith "jsr305")) 

--- a/src/main/scala/de/johoop/findbugs4sbt/FindBugs.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/FindBugs.scala
@@ -12,19 +12,40 @@
 package de.johoop.findbugs4sbt
 
 import sbt._
-import Keys._
+import sbt.Keys._
 
-object FindBugs extends Plugin 
+object FindBugs extends Plugin
     with Settings with CommandLine with CommandLineExecutor {
 
-  override def findbugsTask(findbugsClasspath: Classpath, compileClasspath: Classpath, 
-      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File], 
+  override def findbugsTask(findbugsClasspath: Classpath, compileClasspath: Classpath,
+      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File],
       streams: TaskStreams): Unit = {
+
+    val log = streams.log
 
     IO.withTemporaryDirectory { filterPath =>
       val cmd = commandLine(findbugsClasspath, compileClasspath, paths, filters, filterPath, misc, streams)
-      streams.log.debug("FindBugs command line to execute: \"%s\"" format (cmd mkString " "))
-      executeCommandLine(cmd, javaHome, streams.log)
+      log.debug("FindBugs command line to execute: \"%s\"" format (cmd mkString " "))
+      executeCommandLine(cmd, javaHome, log)
     }
+
+    paths.reportPath foreach(f => {
+      val warnings = {
+        val resultFile = paths.reportPath.get
+        val results = scala.xml.XML.loadFile(resultFile)
+        results \\ "BugCollection" \\ "BugInstance"
+      }
+
+      if (warnings.nonEmpty) {
+        val message = s"FindBugs found ${warnings.size} issues"
+        if (misc.failOnError) {
+          sys.error(message)
+        } else {
+          log.info(message)
+        }
+      } else {
+        log.info("No issues from findbugs")
+      }
+    })
   }
 }

--- a/src/sbt-test/findbugs/findbugs-fail/build.sbt
+++ b/src/sbt-test/findbugs/findbugs-fail/build.sbt
@@ -1,0 +1,13 @@
+import de.johoop.findbugs4sbt.FindBugs
+
+name := "findbugs-fail"
+
+organization := "de.johoop"
+
+version := "1.4.1-SNAPSHOT"
+
+FindBugs.findbugsSettings
+
+FindBugs.findbugsFailOnError := true
+
+FindBugs.findbugsReportPath := Some(target.value / "findbugs" / "report.xml")

--- a/src/sbt-test/findbugs/findbugs-fail/project/plugins.sbt
+++ b/src/sbt-test/findbugs/findbugs-fail/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+    val pluginVersion = System.getProperty("plugin.version")
+    if(pluginVersion == null)
+          throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    else addSbtPlugin("de.johoop" % "findbugs4sbt" % pluginVersion)
+}

--- a/src/sbt-test/findbugs/findbugs-fail/src/main/java/de/johoop/findbugs4sbt/TestClass.java
+++ b/src/sbt-test/findbugs/findbugs-fail/src/main/java/de/johoop/findbugs4sbt/TestClass.java
@@ -1,0 +1,26 @@
+package de.johoop.findbugs4sbt;
+
+import java.util.List;
+
+public class TestClass {
+
+  private List<String> strings;
+  private int n;
+
+  public TestClass(int n) {
+    this.n = n;
+  }
+
+  public static void main(String[] args) {
+    System.out.println("Hello, world!");
+  }
+
+  public List<String> getStrings() {
+    return strings;
+  }
+
+  public void setN(int n) {
+    n = n;
+  }
+
+}

--- a/src/sbt-test/findbugs/findbugs-fail/test
+++ b/src/sbt-test/findbugs/findbugs-fail/test
@@ -1,0 +1,3 @@
+# Check the build fails when running findbugs
+-> compile:findbugs
+$ exists target/findbugs/report.xml

--- a/src/sbt-test/findbugs/findbugs/build.sbt
+++ b/src/sbt-test/findbugs/findbugs/build.sbt
@@ -1,0 +1,11 @@
+import de.johoop.findbugs4sbt.FindBugs
+
+name := "findbugs"
+
+organization := "de.johoop"
+
+version := "1.4.1-SNAPSHOT"
+
+FindBugs.findbugsSettings
+
+FindBugs.findbugsReportPath := Some(target.value / "findbugs" / "my-findbugs-report.xml")

--- a/src/sbt-test/findbugs/findbugs/project/plugins.sbt
+++ b/src/sbt-test/findbugs/findbugs/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+    val pluginVersion = System.getProperty("plugin.version")
+    if(pluginVersion == null)
+          throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+    else addSbtPlugin("de.johoop" % "findbugs4sbt" % pluginVersion)
+}

--- a/src/sbt-test/findbugs/findbugs/src/main/java/de/johoop/findbugs4sbt/TestClass.java
+++ b/src/sbt-test/findbugs/findbugs/src/main/java/de/johoop/findbugs4sbt/TestClass.java
@@ -1,0 +1,26 @@
+package de.johoop.findbugs4sbt;
+
+import java.util.List;
+
+public class TestClass {
+
+  private List<String> strings;
+  private int n;
+
+  public TestClass(int n) {
+    this.n = n;
+  }
+
+  public static void main(String[] args) {
+    System.out.println("Hello, world!");
+  }
+
+  public List<String> getStrings() {
+    return strings;
+  }
+
+  public void setN(int n) {
+    n = n;
+  }
+
+}

--- a/src/sbt-test/findbugs/findbugs/test
+++ b/src/sbt-test/findbugs/findbugs/test
@@ -1,0 +1,3 @@
+# Check that the findbugs report is created
+> compile:findbugs
+$ exists target/findbugs/my-findbugs-report.xml


### PR DESCRIPTION
This PR fixes #13 by adding a `findbugsFailOnError` setting to fail the build if any FindBugs issues are found.

I also added some tests for the plugin that run findbugs on the test project and check whether the report is created, you can run them using `sbt scripted`.