### PR TITLE
Added option to break the build if issues are found as well as GUI task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "findbugs4sbt"
 
 organization := "de.johoop"
 
-version := "1.4.0"
+version := "1.4.1-SNAPSHOT"
 
 scalaVersion := "2.10.3"
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ You can execute `findbugs` to analyze your project and produce a report.
 
 You can execute `findbugs-check` to analyze your project, produce an XML report and automatically break the build if issues are found.
 
+You can also execute `findbugs-gui` to display Findbugs GUI. If you previously generated a report, it will be automatically loaded.
+
 ## Defining exclude/include filters
 
 ### Defining filters inline

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ findbugsIncludeFilters := Some(<FindBugsFilter>
 You can also read the filter settings from files in a more conventional way:
 
 ```scala
-findbugsIncludeFilters := Some(baseDirectory.value / "findbugs-include-filters.xml")
+findbugsIncludeFilters := Some(scala.xml.XML.loadFile(baseDirectory.value / "findbugs-include-filters.xml"))
 ```
 
 Or, when your configuration is zipped and previously published to a local repo:

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,12 @@ addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 
 The old settings specified below are still mostly valid, but they're now specified using the settings system of SBT 0.13.
 
+## Executing Findbugs
+
+You can execute `findbugs` to analyze your project and produce a report.
+
+You can execute `findbugs-check` to analyze your project, produce an XML report and automatically break the build if issues are found.
+
 ## Defining exclude/include filters
 
 ### Defining filters inline

--- a/src/main/scala/de/johoop/findbugs4sbt/CommandLine.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/CommandLine.scala
@@ -22,7 +22,7 @@ import ReportType._
 import Priority._
 import Effort._
 
-private[findbugs4sbt] trait CommandLine extends Plugin with Filters with Settings {
+private[findbugs4sbt] trait CommandLine extends Plugin with Filters {
 
   def commandLine(findbugsClasspath: Classpath, compileClasspath: Classpath, 
       paths: PathSettings, filters: FilterSettings, filterPath: File, misc: MiscSettings, streams: TaskStreams) = {
@@ -45,12 +45,19 @@ private[findbugs4sbt] trait CommandLine extends Plugin with Filters with Setting
 
       val auxClasspath = paths.auxPath ++ (findbugsClasspath.files filter (_.getName startsWith "jsr305")) 
       
-      addOnlyAnalyzeParameter(addSortByClassParameter(addFilterFiles(filters, filterPath, 
-        misc.reportType.map(`type` => List(`type`.toString)).getOrElse(Nil) ++
-        paths.reportPath.map(path => List("-output", path.absolutePath)).getOrElse(Nil) ++ List(
-          "-nested:%b".format(misc.analyzeNestedArchives),
-          "-auxclasspath", commandLineClasspath(auxClasspath), misc.priority.toString,
-          "-effort:%s".format(misc.effort.toString)))))
+      addOnlyAnalyzeParameter(
+        addSortByClassParameter(
+          addFilterFiles(
+            filters,
+            filterPath,
+            misc.reportType.map(
+              `type` => List(`type`.toString)).getOrElse(Nil) ++
+              paths.reportPath.map(path => List("-output", path.absolutePath)).getOrElse(Nil) ++
+              List("-nested:%b".format(misc.analyzeNestedArchives),
+                   "-auxclasspath", commandLineClasspath(auxClasspath),
+                   misc.priority.toString,
+                   "-effort:%s".format(misc.effort.toString)
+              ))))
     }
   
     def addOnlyAnalyzeParameter(arguments: List[String]) = misc.onlyAnalyze match {

--- a/src/main/scala/de/johoop/findbugs4sbt/Filters.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Filters.scala
@@ -16,7 +16,7 @@ import sbt._
 import scala.xml.Node
 import scala.xml.XML
 
-private[findbugs4sbt] trait Filters extends Plugin with Settings {
+private[findbugs4sbt] trait Filters extends Plugin {
 
   private[findbugs4sbt] def addFilterFiles(filters: FilterSettings, filterPath: File, options: List[String]) = {
     def addIncludeFilterFile(options: List[String]) = addFilterFile(options, filters.includeFilters, "include")

--- a/src/main/scala/de/johoop/findbugs4sbt/FindBugsCheck.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/FindBugsCheck.scala
@@ -1,0 +1,67 @@
+/*
+ * This file is part of findbugs4sbt.
+ *
+ * Copyright (c) 2010-2014 Joachim Hofer & contributors
+ * All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package de.johoop.findbugs4sbt
+
+import sbt.Keys._
+import sbt._
+
+object FindBugsCheck extends Plugin
+    with CommandLine with CommandLineExecutor {
+
+  def findbugsTask(findbugsClasspath: Classpath, compileClasspath: Classpath,
+      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File],
+      streams: TaskStreams): Unit = {
+
+    IO.withTemporaryDirectory { filterPath =>
+
+      streams.log.info("Task 'findbugs-check' will produce XML output.")
+
+      val customMisc = MiscSettings(Some(ReportType.Xml), misc.priority, misc.onlyAnalyze, misc.maxMemory, misc.analyzeNestedArchives,
+        misc.sortReportByClassNames, misc.effort)
+
+      val cmd = commandLine(findbugsClasspath, compileClasspath, paths, filters, filterPath, customMisc, streams)
+      streams.log.debug("FindBugs command line to execute: \"%s\"" format (cmd mkString " "))
+      val result = executeCommandLine(cmd, javaHome, streams.log)
+
+      streams.log.info("Will fail the build if errors are found in Findbugs report.")
+      var issuesFound = 0
+      val outputFile: File = paths.reportPath.get
+      val report = scala.xml.XML.loadFile(outputFile)
+
+      (report \ "BugInstance").foreach { bugInstance =>
+
+        val category: String = (bugInstance \"@category").text
+        val shortMessage: String = (bugInstance \ "ShortMessage").text
+
+        (bugInstance \ "SourceLine").foreach { sourceLine =>
+          val sourcePath: String = (sourceLine \ "@sourcepath").text
+          val lineNumber: String = (sourceLine \ "@start").text
+
+          streams.log.warn("[%s] %s at %s:%s".format(
+              category,
+              shortMessage,
+              sourcePath,
+              lineNumber
+            )
+          )
+          issuesFound += 1
+        }
+      }
+
+      if (issuesFound > 0) {
+        streams.log.error(issuesFound + " issue(s) found in Findbugs report: " + outputFile + "")
+        sys.exit(1)
+      }
+    }
+  }
+
+}

--- a/src/main/scala/de/johoop/findbugs4sbt/FindBugsGui.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/FindBugsGui.scala
@@ -1,0 +1,43 @@
+/*
+ * This file is part of findbugs4sbt.
+ *
+ * Copyright (c) 2010-2014 Joachim Hofer & contributors
+ * All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package de.johoop.findbugs4sbt
+
+import sbt.Keys._
+import sbt._
+
+
+object FindBugsGui extends Plugin with CommandLineExecutor {
+
+  def task(findbugsClasspath: Classpath, compileClasspath: Classpath,
+      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File],
+      streams: TaskStreams, sources: Seq[File]): Unit = {
+
+      val cmd = commandLine(findbugsClasspath, compileClasspath, paths, filters, misc, streams)
+      streams.log.debug("FindBugs command line to execute: \"%s\"" format (cmd mkString " "))
+      val result = executeCommandLine(cmd, javaHome, streams.log)
+  }
+
+  def commandLine(findbugsClasspath: Classpath, compileClasspath: Classpath,
+                  paths: PathSettings, filters: FilterSettings, misc: MiscSettings, streams: TaskStreams) : List[String] = {
+
+    val classpath = PathFinder(findbugsClasspath.files).absString
+    streams.log.debug("FindBugs classpath: %s" format classpath)
+
+    List("-Xmx%dm".format(misc.maxMemory),
+            "-cp", classpath,
+            "edu.umd.cs.findbugs.LaunchAppropriateUI",
+            "-gui",
+            "-loadBugs", paths.reportPath.get.absolutePath
+    )
+  }
+
+}

--- a/src/main/scala/de/johoop/findbugs4sbt/ReportType.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/ReportType.scala
@@ -14,7 +14,7 @@ package de.johoop.findbugs4sbt
 object ReportType extends Enumeration {
   type ReportType = Value
   
-  val Xml = Value("-xml")
+  val Xml = Value("-xml:withMessages")
   val Html = Value("-html")
   val PlainHtml = Value("-html:plain.xsl")
   val FancyHtml = Value("-html:fancy.xsl")

--- a/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
@@ -35,6 +35,7 @@ private[findbugs4sbt] case class MiscSettings(
 private[findbugs4sbt] trait Settings extends Plugin {
 
   val findbugs = TaskKey[Unit]("findbugs")
+  val findbugsCheck = TaskKey[Unit]("findbugs-check")
 
   val findbugsClasspath = TaskKey[Classpath]("findbugs-classpath")
   val findbugsPathSettings = TaskKey[PathSettings]("findbugs-path-settings")
@@ -91,10 +92,13 @@ private[findbugs4sbt] trait Settings extends Plugin {
       "com.google.code.findbugs" % "findbugs" % "3.0.0" % "findbugs->default",
       "com.google.code.findbugs" % "jsr305" % "3.0.0" % "findbugs->default"
     ),
-      
-    findbugs <<= (findbugsClasspath, managedClasspath in Compile, 
-      findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams) map findbugsTask,
-    
+
+    findbugs <<= (findbugsClasspath, managedClasspath in Compile,
+      findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams) map FindBugs.findbugsTask,
+
+    findbugsCheck <<= (findbugsClasspath, managedClasspath in Compile,
+      findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams) map FindBugsCheck.findbugsTask,
+
     findbugsPathSettings <<= (findbugsReportPath, findbugsAnalyzedPath, findbugsAuxiliaryPath) map PathSettings dependsOn (compile in Compile),
     findbugsFilterSettings <<= (findbugsIncludeFilters, findbugsExcludeFilters) map FilterSettings,
     findbugsMiscSettings <<= (findbugsReportType, findbugsPriority, findbugsOnlyAnalyze, findbugsMaxMemory, 

--- a/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
@@ -35,7 +35,11 @@ private[findbugs4sbt] case class MiscSettings(
 private[findbugs4sbt] trait Settings extends Plugin {
 
   val findbugs = TaskKey[Unit]("findbugs")
+<<<<<<< HEAD
+  val findbugsGui = TaskKey[Unit]("findbugs-gui")
+=======
   val findbugsCheck = TaskKey[Unit]("findbugs-check")
+>>>>>>> redmart/master
 
   val findbugsClasspath = TaskKey[Classpath]("findbugs-classpath")
   val findbugsPathSettings = TaskKey[PathSettings]("findbugs-path-settings")
@@ -98,6 +102,9 @@ private[findbugs4sbt] trait Settings extends Plugin {
 
     findbugsCheck <<= (findbugsClasspath, managedClasspath in Compile,
       findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams) map FindBugsCheck.findbugsTask,
+
+    findbugsGui <<= (findbugsClasspath, managedClasspath in Compile,
+      findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams, unmanagedSources in Compile) map FindBugsGui.task,
 
     findbugsPathSettings <<= (findbugsReportPath, findbugsAnalyzedPath, findbugsAuxiliaryPath) map PathSettings dependsOn (compile in Compile),
     findbugsFilterSettings <<= (findbugsIncludeFilters, findbugsExcludeFilters) map FilterSettings,

--- a/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
@@ -35,11 +35,8 @@ private[findbugs4sbt] case class MiscSettings(
 private[findbugs4sbt] trait Settings extends Plugin {
 
   val findbugs = TaskKey[Unit]("findbugs")
-<<<<<<< HEAD
   val findbugsGui = TaskKey[Unit]("findbugs-gui")
-=======
   val findbugsCheck = TaskKey[Unit]("findbugs-check")
->>>>>>> redmart/master
 
   val findbugsClasspath = TaskKey[Classpath]("findbugs-classpath")
   val findbugsPathSettings = TaskKey[PathSettings]("findbugs-path-settings")


### PR DESCRIPTION
You can now execute `findbugs-check` to analyze your project, produce an XML report and automatically break the build if issues are found.

You can also execute `findbugs-gui` to display Findbugs GUI. If you previously generated a report, it will be automatically loaded.
